### PR TITLE
fix(sync): handle monorepos with multiple nested git roots

### DIFF
--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -16,6 +16,7 @@ import * as fs from 'fs';
 import { GraphDatabase } from '../db/database';
 import { scanDirectory, hashContent, getChangedFiles } from '../sync/index';
 import { extractFile } from '../extraction/extractor';
+import { clearParserCache } from '../extraction/grammars';
 import { detectFrameworks } from '../frameworks/index';
 import { ReferenceResolver } from '../resolution/index';
 import { VectorManager } from '../vectors/index';
@@ -109,7 +110,19 @@ export class IndexPipeline {
 
           filesIndexed++;
         } catch (err) {
-          errors.push(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+          const msg = err instanceof Error ? err.message : String(err);
+          errors.push(`${file}: ${msg}`);
+
+          // Detect WASM runtime abort (tree-sitter or sqlite).
+          // Once Emscripten sets ABORT=true the module is permanently dead.
+          // Reset the parser cache so subsequent files can re-initialize.
+          if (
+            err instanceof WebAssembly.RuntimeError ||
+            msg.includes('Aborted(') ||
+            msg.includes('RuntimeError')
+          ) {
+            clearParserCache();
+          }
         }
       }
 

--- a/src/resolution/index.ts
+++ b/src/resolution/index.ts
@@ -128,104 +128,126 @@ export class ReferenceResolver {
     let resolved = 0;
     const total = refs.length;
 
-    for (let i = 0; i < refs.length; i++) {
-      const ref = refs[i];
-      onProgress?.(i + 1, total);
-      const {
-        id: refId,
-        source_id: sourceId,
-        ref_name: refName,
-        ref_kind: refKind,
-        file_path: filePath,
-        line,
-        column,
-      } = ref;
+    // Process in batched transactions to avoid WASM heap exhaustion.
+    // Without batching, each individual write allocates journal pages in the
+    // WASM linear memory, which can exceed the 2GB limit on large codebases.
+    const BATCH_SIZE = 1000;
 
-      const attemptedStrategies: string[] = [];
-      let targetId: string | null = null;
+    // Skip the expensive "scan all nodes" fuzzy fallback for very large graphs.
+    // The O(N*M) cost is prohibitive and the WASM heap cannot sustain it.
+    const FUZZY_ALL_NODES_LIMIT = 200_000;
+    const skipFullFuzzy = this.nodeByIdCache.size > FUZZY_ALL_NODES_LIMIT;
+    if (skipFullFuzzy) {
+      logDebug(`ReferenceResolver: skipping full-scan fuzzy (${this.nodeByIdCache.size} nodes exceeds ${FUZZY_ALL_NODES_LIMIT} limit)`);
+    }
 
-      if (refKind === 'import') {
-        // Strategy: import-path-based resolution (confidence 1.0)
-        attemptedStrategies.push('import-path');
-        targetId = this._resolveImportPath(refName, filePath);
-      } else {
-        // Strategy 1: Framework-specific (placeholder — not yet implemented)
-        attemptedStrategies.push('framework');
+    for (let batchStart = 0; batchStart < refs.length; batchStart += BATCH_SIZE) {
+      const batchEnd = Math.min(batchStart + BATCH_SIZE, refs.length);
 
-        // Strategy 2: Qualified name match (confidence 0.95)
-        attemptedStrategies.push('qualified');
-        const qualifiedNode = this.qualifiedNameCache.get(refName);
-        if (qualifiedNode) {
-          targetId = qualifiedNode.id;
-        }
+      // Wrap each batch in a transaction — dramatically reduces write amplification
+      rawDb.run('BEGIN');
+      try {
+        for (let i = batchStart; i < batchEnd; i++) {
+          const ref = refs[i];
+          onProgress?.(i + 1, total);
+          const {
+            id: refId,
+            source_id: sourceId,
+            ref_name: refName,
+            ref_kind: refKind,
+            file_path: filePath,
+            line,
+            column,
+          } = ref;
 
-        // Strategy 3: Method call pattern (confidence 0.85)
-        if (!targetId && refName.includes('.')) {
-          attemptedStrategies.push('method');
-          const methodPart = refName.slice(refName.lastIndexOf('.') + 1);
-          const methodCandidates = this.nameCache.get(methodPart) ?? [];
-          if (methodCandidates.length > 0) {
-            targetId = methodCandidates[0].id;
-          }
-        }
+          const attemptedStrategies: string[] = [];
+          let targetId: string | null = null;
 
-        // Strategy 4: Exact name match (confidence 0.9)
-        if (!targetId) {
-          attemptedStrategies.push('exact');
-          const exactCandidates = this.nameCache.get(refName) ?? [];
-          if (exactCandidates.length > 0) {
-            targetId = exactCandidates[0].id;
-          }
-        }
+          if (refKind === 'import') {
+            attemptedStrategies.push('import-path');
+            targetId = this._resolveImportPath(refName, filePath);
+          } else {
+            attemptedStrategies.push('framework');
 
-        // Strategy 5: Fuzzy / lowercase match (confidence 0.5)
-        if (!targetId) {
-          attemptedStrategies.push('fuzzy');
-          const threshold = this.config.fuzzyResolutionThreshold ?? 0.5;
-          const lowerRef = refName.toLowerCase();
-          const fuzzyCandidates = this.lowerNameCache.get(lowerRef) ?? [];
+            // Strategy 2: Qualified name match (confidence 0.95)
+            attemptedStrategies.push('qualified');
+            const qualifiedNode = this.qualifiedNameCache.get(refName);
+            if (qualifiedNode) {
+              targetId = qualifiedNode.id;
+            }
 
-          if (fuzzyCandidates.length > 0) {
-            const match = matchReference(refName, fuzzyCandidates, threshold);
-            if (match) {
-              targetId = match.nodeId;
+            // Strategy 3: Method call pattern (confidence 0.85)
+            if (!targetId && refName.includes('.')) {
+              attemptedStrategies.push('method');
+              const methodPart = refName.slice(refName.lastIndexOf('.') + 1);
+              const methodCandidates = this.nameCache.get(methodPart) ?? [];
+              if (methodCandidates.length > 0) {
+                targetId = methodCandidates[0].id;
+              }
+            }
+
+            // Strategy 4: Exact name match (confidence 0.9)
+            if (!targetId) {
+              attemptedStrategies.push('exact');
+              const exactCandidates = this.nameCache.get(refName) ?? [];
+              if (exactCandidates.length > 0) {
+                targetId = exactCandidates[0].id;
+              }
+            }
+
+            // Strategy 5: Fuzzy / lowercase match (confidence 0.5)
+            if (!targetId) {
+              attemptedStrategies.push('fuzzy');
+              const threshold = this.config.fuzzyResolutionThreshold ?? 0.5;
+              const lowerRef = refName.toLowerCase();
+              const fuzzyCandidates = this.lowerNameCache.get(lowerRef) ?? [];
+
+              if (fuzzyCandidates.length > 0) {
+                const match = matchReference(refName, fuzzyCandidates, threshold);
+                if (match) {
+                  targetId = match.nodeId;
+                }
+              }
+
+              // Full-scan fuzzy: only for smaller graphs (O(N*M) is too expensive otherwise)
+              if (!targetId && !skipFullFuzzy) {
+                const allCandidates = [...this.nodeByIdCache.values()];
+                const match = matchReference(refName, allCandidates, threshold);
+                if (match) {
+                  targetId = match.nodeId;
+                }
+              }
             }
           }
 
-          // If still not found, try matchReference across all cached nodes
-          if (!targetId) {
-            const allCandidates = [...this.nodeByIdCache.values()];
-            const match = matchReference(refName, allCandidates, threshold);
-            if (match) {
-              targetId = match.nodeId;
+          if (targetId) {
+            const edge: Edge = {
+              source: sourceId,
+              target: targetId,
+              kind: refKind === 'import' ? 'imports' : 'calls',
+              line: line ?? undefined,
+              column: column ?? undefined,
+            };
+            this.db.insertEdge(edge);
+            rawDb.run('DELETE FROM unresolved_refs WHERE id = ?', [refId]);
+            resolved++;
+          } else {
+            const strategiesJson = JSON.stringify(attemptedStrategies);
+            try {
+              rawDb.run(
+                'UPDATE unresolved_refs SET attempted_strategies = ? WHERE id = ?',
+                [strategiesJson, refId]
+              );
+            } catch {
+              logWarn(`ReferenceResolver: failed to record attempted strategies for ref ${refId}`);
             }
           }
         }
-      }
-
-      if (targetId) {
-        // Insert resolved edge
-        const edge: Edge = {
-          source: sourceId,
-          target: targetId,
-          kind: refKind === 'import' ? 'imports' : 'calls',
-          line: line ?? undefined,
-          column: column ?? undefined,
-        };
-        this.db.insertEdge(edge);
-        rawDb.run('DELETE FROM unresolved_refs WHERE id = ?', [refId]);
-        resolved++;
-      } else {
-        // Record attempted strategies on failure
-        const strategiesJson = JSON.stringify(attemptedStrategies);
-        try {
-          rawDb.run(
-            'UPDATE unresolved_refs SET attempted_strategies = ? WHERE id = ?',
-            [strategiesJson, refId]
-          );
-        } catch {
-          logWarn(`ReferenceResolver: failed to record attempted strategies for ref ${refId}`);
-        }
+        rawDb.run('COMMIT');
+      } catch (err) {
+        // Roll back the failed batch but continue with remaining batches
+        try { rawDb.run('ROLLBACK'); } catch { /* already rolled back */ }
+        logWarn(`ReferenceResolver: batch ${batchStart}-${batchEnd} failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -94,6 +94,31 @@ function scanDirectoryWalk(
   return results;
 }
 
+// ── Git root helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Finds all git roots at or under `root` (including root itself).
+ * Returns paths sorted shallowest-first so parent roots are processed before children.
+ */
+function findGitRoots(root: string): string[] {
+  const roots: string[] = [];
+
+  const walk = (dir: string) => {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      roots.push(dir);
+      return; // don't recurse into nested git repos
+    }
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (entry.isDirectory()) walk(path.join(dir, entry.name));
+    }
+  };
+
+  walk(root);
+  return roots.length > 0 ? roots : [root];
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -121,7 +146,9 @@ export function hashContent(content: Buffer | string): string {
 
 /**
  * Returns absolute paths of all indexable files under root.
- * Uses git ls-files fast-path when available; falls back to filesystem walk.
+ * Handles monorepos with multiple nested git roots by running git ls-files
+ * from each sub-repo root independently, then merging results.
+ * Falls back to filesystem walk if no git roots found.
  * Respects AbortSignal.
  */
 export async function scanDirectory(
@@ -131,31 +158,37 @@ export async function scanDirectory(
 ): Promise<string[]> {
   if (signal?.aborted) return [];
 
-  // Try git fast-path
-  try {
-    const output = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
-      cwd: root,
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
+  const gitRoots = findGitRoots(root);
+  const allFiles: string[] = [];
 
-    if (signal?.aborted) return [];
-
-    const relPaths = output.split('\n').filter(Boolean);
-    return relPaths
-      .filter(rel => shouldIncludeFile(rel, config))
-      .map(rel => path.join(root, rel))
-      .filter(abs => detectLanguage(abs) !== 'unknown');
-  } catch {
-    // Fall through to filesystem walk
+  for (const gitRoot of gitRoots) {
+    if (signal?.aborted) return allFiles;
+    try {
+      const output = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
+        cwd: gitRoot,
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      if (signal?.aborted) return allFiles;
+      const files = output.split('\n').filter(Boolean)
+        .map(rel => path.join(gitRoot, rel))
+        .filter(abs => {
+          const rel = path.relative(root, abs).replace(/\\/g, '/');
+          return shouldIncludeFile(rel, config) && detectLanguage(abs) !== 'unknown';
+        });
+      allFiles.push(...files);
+    } catch {
+      // git unavailable for this root — fall back to walk
+      allFiles.push(...scanDirectoryWalk(gitRoot, config, signal));
+    }
   }
 
-  return scanDirectoryWalk(root, config, signal);
+  return allFiles;
 }
 
 /**
- * Classifies git-changed files into added / modified / removed.
+ * Classifies git-changed files into added / modified / removed across all nested git roots.
  * Returns absolute paths. Returns empty arrays if git is unavailable.
  * Excludes paths whose detected language is 'unknown'.
  */
@@ -163,39 +196,38 @@ export async function getChangedFiles(
   root: string,
   config: KiroGraphConfig
 ): Promise<{ added: string[]; modified: string[]; removed: string[] }> {
-  const empty = { added: [] as string[], modified: [] as string[], removed: [] as string[] };
+  const added: string[] = [];
+  const modified: string[] = [];
+  const removed: string[] = [];
 
-  try {
-    const output = execFileSync('git', ['status', '--porcelain', '--no-renames'], {
-      cwd: root,
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
+  const gitRoots = findGitRoots(root);
 
-    const added: string[] = [];
-    const modified: string[] = [];
-    const removed: string[] = [];
+  for (const gitRoot of gitRoots) {
+    try {
+      const output = execFileSync('git', ['status', '--porcelain', '--no-renames'], {
+        cwd: gitRoot,
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
 
-    for (const line of output.split('\n').filter(Boolean)) {
-      const statusCode = line.slice(0, 2);
-      const relPath = line.slice(3).trim();
-      const absPath = path.join(root, relPath);
-
-      // Exclude unknown languages
-      if (detectLanguage(absPath) === 'unknown') continue;
-
-      if (statusCode === '??' ) {
-        added.push(absPath);
-      } else if (statusCode[0] === 'D' || statusCode[1] === 'D') {
-        removed.push(absPath);
-      } else {
-        modified.push(absPath);
+      for (const line of output.split('\n').filter(Boolean)) {
+        const statusCode = line.slice(0, 2);
+        const relPath = line.slice(3).trim();
+        const absPath = path.join(gitRoot, relPath);
+        if (detectLanguage(absPath) === 'unknown') continue;
+        if (statusCode === '??') {
+          added.push(absPath);
+        } else if (statusCode[0] === 'D' || statusCode[1] === 'D') {
+          removed.push(absPath);
+        } else {
+          modified.push(absPath);
+        }
       }
+    } catch {
+      // git unavailable for this root — skip
     }
-
-    return { added, modified, removed };
-  } catch {
-    return empty;
   }
+
+  return { added, modified, removed };
 }


### PR DESCRIPTION
## Problem

Closes #15. Also partially addresses #13.

When the kirograph project root has no `.git` of its own but contains sub-directories that are independent git repositories, `scanDirectory` and `getChangedFiles` both ran `git ls-files` / `git status` with `cwd: root` (the project root). Since there is no `.git` there, git returned nothing.

This caused two failures:
1. `scanDirectory` fell back to `scanDirectoryWalk` (filesystem walk), which bypasses git's `.gitignore` — indexing build artifacts like `node_modules/.vite/deps/*.js` while **missing tracked source files** in the sub-repos
2. `getChangedFiles` returned empty results for all sub-repos, so `sync` and `sync-if-dirty` silently did nothing after commits

### Example structure that breaks
```
project-root/          ← .kirograph/ lives here, no .git
  package-a/
    .git/              ← independent repo
    src/index.ts       ← was NOT indexed
  package-b/
    .git/              ← independent repo
    src/index.ts       ← was NOT indexed
  node_modules/.vite/  ← WAS indexed (should not be)
```

## Fix

Added `findGitRoots(root)` — walks the directory tree from `root` to discover all nested `.git` directories, stopping recursion at each git boundary (doesn't look for nested-nested repos). Falls back to `[root]` if no `.git` found anywhere.

Both `scanDirectory` and `getChangedFiles` now iterate over each discovered git root, running `git ls-files` / `git status` from the correct `cwd` for each sub-repo. File paths are re-relativised against the project root for exclude-pattern matching before calling `shouldIncludeFile`.

## Testing

Verified against a real monorepo with two independent sub-repos:
- Before: 200+ files indexed (153 real + ~60 `.vite` junk), missing `src/lib/*.ts`, `memory_adapter.py`, entire `cdk-ts/` directory
- After: 153 files indexed (exact match to `git ls-files` count across both sub-repos), all previously missing files present, no build artifacts