### PR TITLE
fix(cli): read version from package.json instead of hardcoding it

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -21,6 +21,8 @@ const root = path.resolve(__dirname, '..');
 const src = path.join(root, 'src');
 const dist = path.join(root, 'dist');
 
+const { version } = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
 const isWatch = process.argv.includes('--watch');
 
 // ── Collect all .ts entry points ─────────────────────────────────────────────
@@ -114,6 +116,7 @@ const sharedOptions: esbuild.BuildOptions = {
   packages: 'external',
   sourcemap: true,
   logLevel: 'info',
+  define: { __CLI_VERSION__: JSON.stringify(version) },
   plugins: [fixDynamicImportsPlugin],
 };
 

--- a/src/bin/kirograph.ts
+++ b/src/bin/kirograph.ts
@@ -32,12 +32,14 @@ import { register as registerSnapshot } from './commands/snapshot';
 import { register as registerPath } from './commands/path';
 import { register as registerExport } from './commands/export';
 
+declare const __CLI_VERSION__: string;
+
 const program = new Command();
 
 program
   .name('kirograph')
   .description('Semantic code knowledge graph for Kiro')
-  .version('0.1.0')
+  .version(__CLI_VERSION__)
   .addHelpCommand(true)
   .hook('preAction', (thisCommand) => {
     const name = thisCommand.name();


### PR DESCRIPTION
## Problem

`kirograph --version` always reports `0.1.0` because the version string in `src/bin/kirograph.ts` was hardcoded and never updated as the package evolved. The current `package.json` is at `0.11.0`.

## Fix

Inject the version at build time via an esbuild `define`, reading it from `package.json`. This ensures `--version` always stays in sync automatically — no manual update needed on future releases.

**Changes:**
- `scripts/build.ts`: read `version` from `package.json` and pass it as `__CLI_VERSION__` via esbuild `define`
- `src/bin/kirograph.ts`: replace hardcoded `'0.1.0'` with the injected `__CLI_VERSION__` constant

## Verification

```
$ kirograph --version
0.11.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)