### PR TITLE
Add multi-client installer targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ kirograph uninit [path]                  # Remove .kirograph/ and Kiro integrati
 kirograph uninit --target all --force    # Skip confirmation and clean all supported integration files
 ```
 
-This removes:
+Without `--force`, KiroGraph asks separately whether to remove the selected tool integration files and whether to remove the shared `.kirograph/` data.
+
+This can remove:
 - `.kirograph/` — index database, snapshots, and export directory
 - Kiro target: `.kiro/hooks/kirograph-*.json`, `.kiro/steering/kirograph.md`, `.kiro/agents/kirograph.json`
 - Claude target: `kirograph` from `.mcp.json`, plus the KiroGraph import from `CLAUDE.md`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![KiroGraph terminal](assets/terminal.png)
 
-Semantic code knowledge graph for [Kiro](https://kiro.dev): fewer tool calls, instant symbol lookups, 100% local.
+Semantic code knowledge graph for [Kiro](https://kiro.dev) and MCP-capable coding agents: fewer tool calls, instant symbol lookups, 100% local.
 
 Inspired by [CodeGraph](https://github.com/colbymchenry/codegraph) by [colbymchenry](https://github.com/colbymchenry) for Claude Code, rebuilt natively for Kiro's MCP and hooks system.
 
@@ -25,7 +25,7 @@ KiroGraph uses [tree-sitter](https://tree-sitter.github.io/tree-sitter/) to pars
 
 Everything is stored in a local SQLite database (`.kirograph/kirograph.db`). **Nothing leaves your machine.** No API keys. No external services.
 
-The index is kept fresh automatically via Kiro hooks — no background watcher process needed.
+The index is kept fresh automatically via Kiro hooks when using the Kiro integration — no background watcher process needed.
 
 ## How Indexing Works
 
@@ -109,15 +109,15 @@ kirograph --version
 ### Remove from a project
 
 ```bash
-kirograph uninit [path]     # Remove .kirograph/, hooks, and steering file from the project
-kirograph uninit --force    # Skip confirmation prompt
+kirograph uninit [path]                  # Remove .kirograph/ and Kiro integration files
+kirograph uninit --target all --force    # Skip confirmation and clean all supported integration files
 ```
 
 This removes:
 - `.kirograph/` — index database, snapshots, and export directory
-- `.kiro/hooks/kirograph-*.json` — all KiroGraph hooks
-- `.kiro/steering/kirograph.md` — the steering file
-- `.kiro/agents/kirograph.json` — the CLI agent config
+- Kiro target: `.kiro/hooks/kirograph-*.json`, `.kiro/steering/kirograph.md`, `.kiro/agents/kirograph.json`
+- Claude target: `kirograph` from `.mcp.json`, plus the KiroGraph import from `CLAUDE.md`
+- Codex target: the generated KiroGraph block from `AGENTS.md`
 
 ### Remove the CLI globally
 
@@ -138,8 +138,12 @@ npm uninstall -g .
 
 ```bash
 # In your project:
-kirograph install    # wire up MCP + hooks + steering + CLI agent in .kiro/
+kirograph install                  # wire up Kiro MCP + hooks + steering + CLI agent
+kirograph install --target claude  # wire up Claude Code MCP + project memory
+kirograph install --target codex   # write Codex instructions and print MCP config
 ```
+
+All targets share the same `.kirograph/` data. If the project is already initialized, installing another target only writes that tool's integration files and reuses the existing graph configuration.
 
 Restart Kiro IDE, or switch to the `kirograph` agent in Kiro CLI. It will now use KiroGraph tools automatically.
 
@@ -176,7 +180,7 @@ Kiro hooks mark the index dirty on every file save or create, then flush on agen
 
 ## Using with Kiro
 
-`kirograph install` sets up four things in your Kiro workspace — all coexist, so you can switch between IDE and CLI freely:
+`kirograph install` or `kirograph install --target kiro` sets up four things in your Kiro workspace — all coexist, so you can switch between IDE and CLI freely:
 
 ### MCP Server (`.kiro/settings/mcp.json`)
 
@@ -193,7 +197,8 @@ Registers the KiroGraph MCP server. Used by both the IDE and the CLI agent:
         "kirograph_callees", "kirograph_impact", "kirograph_node",
         "kirograph_status", "kirograph_files", "kirograph_dead_code",
         "kirograph_circular_deps", "kirograph_path", "kirograph_type_hierarchy",
-        "kirograph_architecture", "kirograph_coupling", "kirograph_package"
+        "kirograph_architecture", "kirograph_coupling", "kirograph_package",
+        "kirograph_hotspots", "kirograph_surprising", "kirograph_diff"
       ]
     }
   }
@@ -243,9 +248,36 @@ Or swap to it inside an active session:
 
 Teaches the Kiro IDE to prefer graph tools over file scanning when `.kirograph/` exists. The CLI agent has the same instructions inlined directly in its `prompt` field.
 
+## Using with Claude Code
+
+```bash
+kirograph install --target claude
+```
+
+This writes:
+
+- `.mcp.json` — project-scoped MCP server config for Claude Code
+- `.kirograph/claude.md` — KiroGraph tool guidance
+- `CLAUDE.md` — an import of `.kirograph/claude.md`
+
+Claude Code prompts for project MCP approval the first time it sees `.mcp.json`.
+
+## Using with Codex
+
+```bash
+kirograph install --target codex
+```
+
+This writes:
+
+- `.kirograph/codex.md` — KiroGraph tool guidance
+- `AGENTS.md` — a generated KiroGraph instruction block
+
+Codex MCP configuration is user-scoped, so the installer prints the exact `codex mcp add ...` command and equivalent `~/.codex/config.toml` snippet instead of editing files outside the project.
+
 ## MCP Tools
 
-All tools are auto-approved and available to Kiro once installed.
+All tools are available to the configured MCP client once installed.
 
 ### `kirograph_context`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kirograph",
   "version": "0.12.1",
-  "description": "Semantic code knowledge graph for Kiro — fewer tool calls, instant symbol lookups, 100% local.",
+  "description": "Semantic code knowledge graph for Kiro and MCP-capable coding agents — fewer tool calls, instant symbol lookups, 100% local.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/bin/commands/caveman.ts
+++ b/src/bin/commands/caveman.ts
@@ -10,6 +10,8 @@ import { loadConfig, updateConfig } from '../../config';
 import { CAVEMAN_RULES, CavemanMode } from '../installer/caveman';
 import { writeSteering } from '../installer/steering';
 import { writeCliAgent } from '../installer/cli-agent';
+import { upsertGeneratedBlock } from '../installer/common';
+import { buildAgentInstructions } from '../installer/instructions';
 import { bold, dim, green, reset, violet } from '../ui';
 
 const JOKES = [
@@ -92,6 +94,17 @@ export function register(program: Command): void {
       const agentPath = path.join(kiroDir, 'agents', 'kirograph.json');
       if (fs.existsSync(agentPath)) {
         writeCliAgent(kiroDir);
+      }
+
+      for (const file of ['claude.md', 'codex.md']) {
+        const instructionsPath = path.join(cwd, '.kirograph', file);
+        if (fs.existsSync(instructionsPath)) {
+          fs.writeFileSync(instructionsPath, buildAgentInstructions(normalized as CavemanMode | 'off'));
+        }
+      }
+      const agentsPath = path.join(cwd, 'AGENTS.md');
+      if (fs.existsSync(agentsPath) && fs.readFileSync(agentsPath, 'utf8').includes('<!-- kirograph:codex:start -->')) {
+        upsertGeneratedBlock(agentsPath, 'codex', '## KiroGraph', buildAgentInstructions(normalized as CavemanMode | 'off'));
       }
 
       console.log();

--- a/src/bin/commands/help.ts
+++ b/src/bin/commands/help.ts
@@ -21,10 +21,10 @@ export function printColoredHelp(): void {
     {
       title: '🔧 Workspace Setup',
       commands: [
-        { name: 'install',       desc: 'Wire up MCP + hooks + steering for the current Kiro workspace' },
+        { name: 'install',       desc: 'Wire up MCP/instructions for an agent workspace', opts: ['--target <t>  kiro | claude | codex'] },
         { name: 'init',          args: '[path]', desc: 'Initialize KiroGraph in a project', opts: ['-i, --index  Index immediately after init'] },
-        { name: 'uninit',        args: '[path]', desc: 'Remove KiroGraph from a project',   opts: ['--force     Skip confirmation'] },
-        { name: 'uninstall',     args: '[path]', desc: 'Alias for uninit',                  opts: ['--force     Skip confirmation'] },
+        { name: 'uninit',        args: '[path]', desc: 'Remove KiroGraph from a project',   opts: ['--force      Skip confirmation', '--target <t>  kiro | claude | codex | all'] },
+        { name: 'uninstall',     args: '[path]', desc: 'Alias for uninit',                  opts: ['--force      Skip confirmation', '--target <t>  kiro | claude | codex | all'] },
       ],
     },
     {
@@ -126,7 +126,9 @@ export function printColoredHelp(): void {
     {
       title: '🔧 Setup & indexing',
       examples: [
-        ['kirograph install',                              'Wire up MCP + hooks + steering for the current workspace'],
+        ['kirograph install',                              'Wire up Kiro MCP + hooks + steering for the current workspace'],
+        ['kirograph install --target claude',              'Wire up Claude Code MCP + project memory'],
+        ['kirograph install --target codex',               'Install Codex project instructions and print MCP config'],
         ['kirograph init --index',                         'Init and immediately index the project'],
         ['kirograph sync',                                 'Incremental sync of changed files'],
       ],

--- a/src/bin/commands/install.ts
+++ b/src/bin/commands/install.ts
@@ -1,11 +1,19 @@
 import { Command } from 'commander';
 
+const INSTALL_TARGETS = ['kiro', 'claude', 'codex'];
+
 export function register(program: Command): void {
   program
     .command('install')
-    .description('Configure KiroGraph for the current Kiro workspace')
-    .action(async () => {
+    .description('Configure KiroGraph for an agent workspace')
+    .option('--target <target>', 'Integration target: kiro, claude, or codex', 'kiro')
+    .action(async (opts: { target: string }) => {
+      const target = opts.target.toLowerCase();
+      if (!INSTALL_TARGETS.includes(target)) {
+        console.error(`Unknown install target: ${opts.target}. Choose from: kiro, claude, codex`);
+        process.exit(1);
+      }
       const { runInstaller } = await import('../installer/index');
-      await runInstaller();
+      await runInstaller(target as 'kiro' | 'claude' | 'codex');
     });
 }

--- a/src/bin/commands/serve.ts
+++ b/src/bin/commands/serve.ts
@@ -10,9 +10,9 @@ export function register(program: Command): void {
     .option('--path <path>', 'Project path')
     .action(async (opts: { mcp?: boolean; path?: string }) => {
       if (!opts.mcp) {
-        console.log(`\n  ${dim}Start the KiroGraph MCP server for Kiro.${reset}`);
+        console.log(`\n  ${dim}Start the KiroGraph MCP server.${reset}`);
         console.log(`\n  ${dim}Usage:${reset}  ${violet}${bold}kirograph serve --mcp${reset}`);
-        console.log(`\n  ${dim}Add to${reset} ${violet}${bold}.kiro/settings/mcp.json${reset}${dim}:${reset}\n`);
+        console.log(`\n  ${dim}Add to your MCP client config:${reset}\n`);
         console.log(`  ${dim}${JSON.stringify({ mcpServers: { kirograph: { command: 'kirograph', args: ['serve', '--mcp'] } } }, null, 2).split('\n').join('\n  ')}${reset}\n`);
         return;
       }

--- a/src/bin/commands/uninit.ts
+++ b/src/bin/commands/uninit.ts
@@ -21,6 +21,15 @@ type UninitTarget = 'kiro' | 'claude' | 'codex' | 'all';
 
 const UNINIT_TARGETS: UninitTarget[] = ['kiro', 'claude', 'codex', 'all'];
 
+async function confirm(question: string): Promise<boolean> {
+  const readline = await import('readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise<boolean>(resolve => rl.question(question, ans => {
+    rl.close();
+    resolve(ans.toLowerCase() === 'y');
+  }));
+}
+
 async function runUninit(projectPath: string | undefined, opts: { force?: boolean; target?: string }): Promise<void> {
   const target = path.resolve(projectPath ?? process.cwd());
   const integration = (opts.target ?? 'kiro').toLowerCase() as UninitTarget;
@@ -30,28 +39,33 @@ async function runUninit(projectPath: string | undefined, opts: { force?: boolea
   }
   const dir = path.join(target, '.kirograph');
   if (!fs.existsSync(dir)) { console.log('Not initialized.'); return; }
+
+  let removeIntegration = true;
+  let removeGraph = opts.force === true;
+
   if (!opts.force) {
     printBanner();
     const farewell = UNINIT_FAREWELLS[Math.floor(Math.random() * UNINIT_FAREWELLS.length)]!;
     console.log(`  ${violet}${bold}${farewell}${reset}`);
-    console.log(`\n  ${dim}This will remove .kirograph/ and ${integration} integration files.${reset}`);
+    console.log(`\n  ${dim}This can remove ${integration} integration files and, separately, the shared .kirograph/ data.${reset}`);
     console.log(`  ${dim}Your source code is untouched.${reset}\n`);
-    const readline = await import('readline');
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    await new Promise<void>(resolve => rl.question(`  ${violet}Remove KiroGraph from this project?${reset} ${dim}(y/N)${reset} `, ans => {
-      rl.close();
-      if (ans.toLowerCase() !== 'y') {
-        console.log(`\n  ${dim}Cancelled. The graph lives on.${reset}\n`);
-        process.exit(0);
-      }
-      resolve();
-    }));
+
+    removeIntegration = await confirm(`  ${violet}Remove ${integration} integration files?${reset} ${dim}(y/N)${reset} `);
+    removeGraph = await confirm(`  ${violet}Remove shared .kirograph/ data too?${reset} ${dim}(y/N)${reset} `);
+
+    if (!removeIntegration && !removeGraph) {
+      console.log(`\n  ${dim}Cancelled. Nothing removed.${reset}\n`);
+      return;
+    }
     console.log();
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-  console.log(`  ${green}✓${reset} Removed .kirograph/`);
 
-  if (integration === 'kiro' || integration === 'all') {
+  if (removeGraph) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    console.log(`  ${green}✓${reset} Removed .kirograph/`);
+  }
+
+  if (removeIntegration && (integration === 'kiro' || integration === 'all')) {
     // Remove .kiro hooks created by kirograph
     const kiroHooks = [
       'kirograph-mark-dirty-on-save.json',
@@ -84,17 +98,17 @@ async function runUninit(projectPath: string | undefined, opts: { force?: boolea
     }
   }
 
-  if (integration === 'claude' || integration === 'all') {
+  if (removeIntegration && (integration === 'claude' || integration === 'all')) {
     const { uninitClaude } = await import('../installer/targets/claude');
     uninitClaude(target);
   }
 
-  if (integration === 'codex' || integration === 'all') {
+  if (removeIntegration && (integration === 'codex' || integration === 'all')) {
     const { uninitCodex } = await import('../installer/targets/codex');
     uninitCodex(target);
   }
 
-  console.log(`\n  ${dim}Done. Run ${violet}kirograph install${reset}${dim} to come back anytime.${reset}\n`);
+  console.log(`\n  ${dim}Done. Run ${violet}kirograph install --target ${integration === 'all' ? 'kiro' : integration}${reset}${dim} to come back anytime.${reset}\n`);
 }
 
 export function register(program: Command): void {

--- a/src/bin/commands/uninit.ts
+++ b/src/bin/commands/uninit.ts
@@ -17,15 +17,24 @@ export const UNINIT_FAREWELLS = [
   "See you on the other side of `kirograph install`.",
 ];
 
-async function runUninit(projectPath: string | undefined, opts: { force?: boolean }): Promise<void> {
+type UninitTarget = 'kiro' | 'claude' | 'codex' | 'all';
+
+const UNINIT_TARGETS: UninitTarget[] = ['kiro', 'claude', 'codex', 'all'];
+
+async function runUninit(projectPath: string | undefined, opts: { force?: boolean; target?: string }): Promise<void> {
   const target = path.resolve(projectPath ?? process.cwd());
+  const integration = (opts.target ?? 'kiro').toLowerCase() as UninitTarget;
+  if (!UNINIT_TARGETS.includes(integration)) {
+    console.error(`Unknown uninit target: ${opts.target}. Choose from: kiro, claude, codex, all`);
+    process.exit(1);
+  }
   const dir = path.join(target, '.kirograph');
   if (!fs.existsSync(dir)) { console.log('Not initialized.'); return; }
   if (!opts.force) {
     printBanner();
     const farewell = UNINIT_FAREWELLS[Math.floor(Math.random() * UNINIT_FAREWELLS.length)]!;
     console.log(`  ${violet}${bold}${farewell}${reset}`);
-    console.log(`\n  ${dim}This will remove .kirograph/, all Kiro hooks, the steering file, and the CLI agent config.${reset}`);
+    console.log(`\n  ${dim}This will remove .kirograph/ and ${integration} integration files.${reset}`);
     console.log(`  ${dim}Your source code is untouched.${reset}\n`);
     const readline = await import('readline');
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -42,35 +51,47 @@ async function runUninit(projectPath: string | undefined, opts: { force?: boolea
   fs.rmSync(dir, { recursive: true, force: true });
   console.log(`  ${green}✓${reset} Removed .kirograph/`);
 
-  // Remove .kiro hooks created by kirograph
-  const kiroHooks = [
-    'kirograph-mark-dirty-on-save.json',
-    'kirograph-mark-dirty-on-create.json',
-    'kirograph-sync-on-delete.json',
-    'kirograph-sync-if-dirty.json',
-    'kirograph-sync-on-save.json',
-    'kirograph-sync-on-create.json',
-  ];
-  const hooksDir = path.join(target, '.kiro', 'hooks');
-  let removedHooks = 0;
-  for (const hook of kiroHooks) {
-    const p = path.join(hooksDir, hook);
-    if (fs.existsSync(p)) { fs.unlinkSync(p); removedHooks++; }
-  }
-  if (removedHooks > 0) console.log(`  ${green}✓${reset} Removed ${removedHooks} hook(s) from .kiro/hooks/`);
+  if (integration === 'kiro' || integration === 'all') {
+    // Remove .kiro hooks created by kirograph
+    const kiroHooks = [
+      'kirograph-mark-dirty-on-save.json',
+      'kirograph-mark-dirty-on-create.json',
+      'kirograph-sync-on-delete.json',
+      'kirograph-sync-if-dirty.json',
+      'kirograph-sync-on-save.json',
+      'kirograph-sync-on-create.json',
+    ];
+    const hooksDir = path.join(target, '.kiro', 'hooks');
+    let removedHooks = 0;
+    for (const hook of kiroHooks) {
+      const p = path.join(hooksDir, hook);
+      if (fs.existsSync(p)) { fs.unlinkSync(p); removedHooks++; }
+    }
+    if (removedHooks > 0) console.log(`  ${green}✓${reset} Removed ${removedHooks} hook(s) from .kiro/hooks/`);
 
-  // Remove .kiro/steering/kirograph.md
-  const steeringPath = path.join(target, '.kiro', 'steering', 'kirograph.md');
-  if (fs.existsSync(steeringPath)) {
-    fs.unlinkSync(steeringPath);
-    console.log(`  ${green}✓${reset} Removed .kiro/steering/kirograph.md`);
+    // Remove .kiro/steering/kirograph.md
+    const steeringPath = path.join(target, '.kiro', 'steering', 'kirograph.md');
+    if (fs.existsSync(steeringPath)) {
+      fs.unlinkSync(steeringPath);
+      console.log(`  ${green}✓${reset} Removed .kiro/steering/kirograph.md`);
+    }
+
+    // Remove .kiro/agents/kirograph.json
+    const agentPath = path.join(target, '.kiro', 'agents', 'kirograph.json');
+    if (fs.existsSync(agentPath)) {
+      fs.unlinkSync(agentPath);
+      console.log(`  ${green}✓${reset} Removed .kiro/agents/kirograph.json`);
+    }
   }
 
-  // Remove .kiro/agents/kirograph.json
-  const agentPath = path.join(target, '.kiro', 'agents', 'kirograph.json');
-  if (fs.existsSync(agentPath)) {
-    fs.unlinkSync(agentPath);
-    console.log(`  ${green}✓${reset} Removed .kiro/agents/kirograph.json`);
+  if (integration === 'claude' || integration === 'all') {
+    const { uninitClaude } = await import('../installer/targets/claude');
+    uninitClaude(target);
+  }
+
+  if (integration === 'codex' || integration === 'all') {
+    const { uninitCodex } = await import('../installer/targets/codex');
+    uninitCodex(target);
   }
 
   console.log(`\n  ${dim}Done. Run ${violet}kirograph install${reset}${dim} to come back anytime.${reset}\n`);
@@ -81,11 +102,13 @@ export function register(program: Command): void {
     .command('uninit [projectPath]')
     .description('Remove KiroGraph from a project')
     .option('--force', 'Skip confirmation')
+    .option('--target <target>', 'Integration target to clean up: kiro, claude, codex, or all', 'kiro')
     .action(runUninit);
 
   program
     .command('uninstall [projectPath]')
     .description('Alias for uninit — remove KiroGraph from a project')
     .option('--force', 'Skip confirmation')
+    .option('--target <target>', 'Integration target to clean up: kiro, claude, codex, or all', 'kiro')
     .action(runUninit);
 }

--- a/src/bin/installer/cli-agent.ts
+++ b/src/bin/installer/cli-agent.ts
@@ -14,29 +14,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-
-const KIROGRAPH_TOOLS = [
-  '@kirograph/kirograph_search',
-  '@kirograph/kirograph_context',
-  '@kirograph/kirograph_callers',
-  '@kirograph/kirograph_callees',
-  '@kirograph/kirograph_impact',
-  '@kirograph/kirograph_node',
-  '@kirograph/kirograph_status',
-  '@kirograph/kirograph_files',
-  '@kirograph/kirograph_dead_code',
-  '@kirograph/kirograph_circular_deps',
-  '@kirograph/kirograph_path',
-  '@kirograph/kirograph_type_hierarchy',
-  '@kirograph/kirograph_architecture',
-  '@kirograph/kirograph_package',
-  '@kirograph/kirograph_coupling',
-  '@kirograph/kirograph_hotspots',
-  '@kirograph/kirograph_surprising',
-  '@kirograph/kirograph_diff',
-];
-
-const SYNC_CMD = 'kirograph sync-if-dirty --quiet 2>/dev/null || true';
+import { KIROGRAPH_SCOPED_TOOLS, KIROGRAPH_SYNC_CMD } from './common';
 
 function buildAgentConfig() {
   return {
@@ -44,12 +22,12 @@ function buildAgentConfig() {
     description: 'KiroGraph-aware agent — uses the semantic code graph for faster, smarter exploration.',
     resources: ['file://.kiro/steering/kirograph.md'],
     tools: ['@builtin', '@kirograph'],
-    allowedTools: KIROGRAPH_TOOLS,
+    allowedTools: KIROGRAPH_SCOPED_TOOLS,
     useLegacyMcpJson: true,
     hooks: {
-      agentSpawn: [{ command: SYNC_CMD }],
-      userPromptSubmit: [{ command: SYNC_CMD }],
-      stop: [{ command: SYNC_CMD }],
+      agentSpawn: [{ command: KIROGRAPH_SYNC_CMD }],
+      userPromptSubmit: [{ command: KIROGRAPH_SYNC_CMD }],
+      stop: [{ command: KIROGRAPH_SYNC_CMD }],
     },
   };
 }

--- a/src/bin/installer/common.ts
+++ b/src/bin/installer/common.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { KIROGRAPH_TOOL_NAMES } from '../../mcp/tool-names';
+
+export type InstallTarget = 'kiro' | 'claude' | 'codex';
+
+export const KIROGRAPH_SERVER_NAME = 'kirograph';
+export const KIROGRAPH_COMMAND = 'kirograph';
+export const KIROGRAPH_MCP_ARGS = ['serve', '--mcp'];
+export const KIROGRAPH_SYNC_CMD = 'kirograph sync-if-dirty --quiet 2>/dev/null || true';
+export const KIROGRAPH_TOOLS = KIROGRAPH_TOOL_NAMES;
+export const KIROGRAPH_SCOPED_TOOLS = KIROGRAPH_TOOL_NAMES.map(name => `@kirograph/${name}`);
+
+export function ensureDir(p: string): void {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+export function readJson(p: string): any {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return {}; }
+}
+
+export function writeJson(p: string, data: unknown): void {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
+}
+
+export function writeMcpServersConfig(configPath: string, serverConfig: object): void {
+  ensureDir(path.dirname(configPath));
+  const existing = readJson(configPath);
+  existing.mcpServers = existing.mcpServers ?? {};
+  existing.mcpServers[KIROGRAPH_SERVER_NAME] = serverConfig;
+  writeJson(configPath, existing);
+}
+
+export function removeMcpServersConfig(configPath: string): boolean {
+  if (!fs.existsSync(configPath)) return false;
+  const existing = readJson(configPath);
+  if (!existing.mcpServers?.[KIROGRAPH_SERVER_NAME]) return false;
+  delete existing.mcpServers[KIROGRAPH_SERVER_NAME];
+  writeJson(configPath, existing);
+  return true;
+}
+
+export function appendImportLine(filePath: string, line: string, heading: string): boolean {
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  if (existing.includes(line)) return false;
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const separator = existing.trim().length > 0 ? '\n' : '';
+  fs.writeFileSync(filePath, existing + prefix + separator + heading + '\n' + line + '\n');
+  return true;
+}
+
+export function removeImportLine(filePath: string, line: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+  const original = fs.readFileSync(filePath, 'utf8');
+  const next = original
+    .split('\n')
+    .filter(l => l.trim() !== line)
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+  if (next === original) return false;
+  fs.writeFileSync(filePath, next.endsWith('\n') ? next : next + '\n');
+  return true;
+}
+
+export function upsertGeneratedBlock(filePath: string, blockId: string, heading: string, content: string): boolean {
+  const start = `<!-- kirograph:${blockId}:start -->`;
+  const end = `<!-- kirograph:${blockId}:end -->`;
+  const block = `${start}\n${heading}\n\n${content.trim()}\n${end}`;
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  const pattern = new RegExp(`${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}`);
+
+  if (pattern.test(existing)) {
+    const next = existing.replace(pattern, block);
+    if (next === existing) return false;
+    fs.writeFileSync(filePath, next.endsWith('\n') ? next : next + '\n');
+    return true;
+  }
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const separator = existing.trim().length > 0 ? '\n' : '';
+  fs.writeFileSync(filePath, existing + prefix + separator + block + '\n');
+  return true;
+}
+
+export function removeGeneratedBlock(filePath: string, blockId: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+  const start = `<!-- kirograph:${blockId}:start -->`;
+  const end = `<!-- kirograph:${blockId}:end -->`;
+  const original = fs.readFileSync(filePath, 'utf8');
+  const pattern = new RegExp(`\\n?${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}\\n?`);
+  const next = original.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n');
+  if (next === original) return false;
+  fs.writeFileSync(filePath, next.endsWith('\n') ? next : next + '\n');
+  return true;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/bin/installer/index.ts
+++ b/src/bin/installer/index.ts
@@ -1,130 +1,140 @@
 /**
- * KiroGraph Installer for Kiro
+ * KiroGraph Installer
  *
- * Wires up:
+ * The default target wires up Kiro:
  *  1. .kiro/settings/mcp.json        — registers the MCP server (IDE + CLI)
  *  2. .kiro/hooks/*.json             — auto-sync hooks for Kiro IDE
  *  3. .kiro/steering/kirograph.md    — teaches Kiro to use the graph tools (IDE + CLI)
  *  4. .kiro/agents/kirograph.json    — custom agent config for Kiro CLI
  */
 
-import * as path from 'path';
 import * as readline from 'readline';
+import * as fs from 'fs';
+import * as path from 'path';
 import { spawnSync } from 'child_process';
-import { updateConfig } from '../../config';
+import { loadConfig, updateConfig } from '../../config';
 import { printBanner } from '../banner';
 import { renderIndexProgress } from '../progress';
 import { dim, reset } from '../ui';
 import { ask } from './prompts';
 import { promptConfigOptions } from './config-prompt';
-import { writeMcpConfig } from './mcp';
-import { writeHooks } from './hooks';
-import { writeSteering } from './steering';
-import { writeCliAgent } from './cli-agent';
 import { openTypesenseDashboard } from './dashboard';
 import { ensureQdrantUI, openQdrantDashboard } from './qdrant-dashboard';
+import type { InstallTarget } from './common';
+import { getTargetInstaller } from './targets';
+import type { CavemanMode } from './caveman';
 
-export async function runInstaller(): Promise<void> {
+export async function runInstaller(target: InstallTarget = 'kiro'): Promise<void> {
   printBanner();
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
   try {
     const cwd = process.cwd();
-    const kiroDir = path.join(cwd, '.kiro');
+    const installer = getTargetInstaller(target);
 
     console.log(`  Workspace: ${cwd}\n`);
 
-    const proceed = await ask(rl, '  Install KiroGraph for this Kiro workspace? (Y/n) ');
+    const proceed = await ask(rl, `  Install KiroGraph for ${installer.label}? (Y/n) `);
     if (proceed.toLowerCase() === 'n') { console.log('  Cancelled.'); rl.close(); return; }
     console.log();
 
-    // 1. MCP config
-    writeMcpConfig(kiroDir);
+    installer.installEarly(cwd);
 
-    // 2. IDE hooks
-    writeHooks(kiroDir);
+    const alreadyInitialized = fs.existsSync(path.join(cwd, '.kirograph'));
+    let cavemanMode: CavemanMode | 'off' = 'off';
+    let shouldOfferIndex = false;
+    let typesenseDashboard = false;
+    let qdrantDashboard = false;
 
-    // 3. Steering written after config prompt (needs cavemanMode) — deferred below
-
-    // 3b. Prompt for config options and persist
-    const patch = await promptConfigOptions(rl);
     try {
-      await updateConfig(cwd, patch);
-      console.log(`\n  Configuration saved to ${cwd}/.kirograph/config.json`);
-      console.log(`  • enableEmbeddings: ${patch.enableEmbeddings}`);
-      if ('embeddingModel' in patch) {
-        console.log(`  • embeddingModel: ${patch.embeddingModel}  ${dim}(${patch.embeddingDim}-dim)${reset}`);
-      }
-      if (patch.enableEmbeddings) {
-        console.log(`  • semanticEngine: ${patch.semanticEngine}`);
-        if (patch.semanticEngine === 'sqlite-vec') {
-          console.log(`\n  Installing sqlite-vec dependencies...`);
-          const result = spawnSync('npm', ['install', 'better-sqlite3', 'sqlite-vec'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ better-sqlite3 and sqlite-vec installed`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install better-sqlite3 sqlite-vec`);
-          }
-        } else if (patch.semanticEngine === 'orama') {
-          console.log(`\n  Installing Orama dependencies...`);
-          const result = spawnSync('npm', ['install', '@orama/orama', '@orama/plugin-data-persistence'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ @orama/orama and @orama/plugin-data-persistence installed`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install @orama/orama @orama/plugin-data-persistence`);
-          }
-        } else if (patch.semanticEngine === 'pglite') {
-          console.log(`\n  Installing PGlite dependencies...`);
-          const result = spawnSync('npm', ['install', '@electric-sql/pglite'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ @electric-sql/pglite installed`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install @electric-sql/pglite`);
-          }
-        } else if (patch.semanticEngine === 'lancedb') {
-          console.log(`\n  Installing LanceDB dependencies...`);
-          const result = spawnSync('npm', ['install', '@lancedb/lancedb'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ @lancedb/lancedb installed`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install @lancedb/lancedb`);
-          }
-        } else if (patch.semanticEngine === 'qdrant') {
-          console.log(`\n  Installing Qdrant dependencies...`);
-          const result = spawnSync('npm', ['install', 'qdrant-local'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ qdrant-local installed`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install qdrant-local`);
-          }
-        } else if (patch.semanticEngine === 'typesense') {
-          console.log(`\n  Installing Typesense dependencies...`);
-          const result = spawnSync('npm', ['install', 'typesense'], { stdio: 'inherit', shell: true });
-          if (result.status === 0) {
-            console.log(`  ✓ typesense installed`);
-            console.log(`  ℹ  The Typesense binary (~37MB) will be auto-downloaded on first index run.`);
-          } else {
-            console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
-            console.warn(`    npm install typesense`);
+      if (alreadyInitialized) {
+        const config = await loadConfig(cwd);
+        cavemanMode = config.cavemanMode ?? 'off';
+        console.log(`  ✓ Reusing existing KiroGraph data in ${cwd}/.kirograph/`);
+        console.log(`  • semanticEngine: ${config.semanticEngine}`);
+        console.log(`  • enableEmbeddings: ${config.enableEmbeddings}`);
+        console.log(`  • enableArchitecture: ${config.enableArchitecture}`);
+        console.log(`  • cavemanMode: ${cavemanMode}`);
+      } else {
+        shouldOfferIndex = true;
+        const patch = await promptConfigOptions(rl);
+        await updateConfig(cwd, patch);
+        cavemanMode = patch.cavemanMode ?? 'off';
+        typesenseDashboard = patch.typesenseDashboard;
+        qdrantDashboard = patch.qdrantDashboard;
+
+        console.log(`\n  Configuration saved to ${cwd}/.kirograph/config.json`);
+        console.log(`  • enableEmbeddings: ${patch.enableEmbeddings}`);
+        if ('embeddingModel' in patch) {
+          console.log(`  • embeddingModel: ${patch.embeddingModel}  ${dim}(${patch.embeddingDim}-dim)${reset}`);
+        }
+        if (patch.enableEmbeddings) {
+          console.log(`  • semanticEngine: ${patch.semanticEngine}`);
+          if (patch.semanticEngine === 'sqlite-vec') {
+            console.log(`\n  Installing sqlite-vec dependencies...`);
+            const result = spawnSync('npm', ['install', 'better-sqlite3', 'sqlite-vec'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ better-sqlite3 and sqlite-vec installed`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install better-sqlite3 sqlite-vec`);
+            }
+          } else if (patch.semanticEngine === 'orama') {
+            console.log(`\n  Installing Orama dependencies...`);
+            const result = spawnSync('npm', ['install', '@orama/orama', '@orama/plugin-data-persistence'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ @orama/orama and @orama/plugin-data-persistence installed`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install @orama/orama @orama/plugin-data-persistence`);
+            }
+          } else if (patch.semanticEngine === 'pglite') {
+            console.log(`\n  Installing PGlite dependencies...`);
+            const result = spawnSync('npm', ['install', '@electric-sql/pglite'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ @electric-sql/pglite installed`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install @electric-sql/pglite`);
+            }
+          } else if (patch.semanticEngine === 'lancedb') {
+            console.log(`\n  Installing LanceDB dependencies...`);
+            const result = spawnSync('npm', ['install', '@lancedb/lancedb'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ @lancedb/lancedb installed`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install @lancedb/lancedb`);
+            }
+          } else if (patch.semanticEngine === 'qdrant') {
+            console.log(`\n  Installing Qdrant dependencies...`);
+            const result = spawnSync('npm', ['install', 'qdrant-local'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ qdrant-local installed`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install qdrant-local`);
+            }
+          } else if (patch.semanticEngine === 'typesense') {
+            console.log(`\n  Installing Typesense dependencies...`);
+            const result = spawnSync('npm', ['install', 'typesense'], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+              console.log(`  ✓ typesense installed`);
+              console.log(`  ℹ  The Typesense binary (~37MB) will be auto-downloaded on first index run.`);
+            } else {
+              console.warn(`  ✗ npm install failed (exit ${result.status}). Run manually:`);
+              console.warn(`    npm install typesense`);
+            }
           }
         }
+        console.log(`  • extractDocstrings: ${patch.extractDocstrings}`);
+        console.log(`  • trackCallSites: ${patch.trackCallSites}`);
+        console.log(`  • enableArchitecture: ${patch.enableArchitecture}`);
+        console.log(`  • cavemanMode: ${cavemanMode}`);
       }
-      console.log(`  • extractDocstrings: ${patch.extractDocstrings}`);
-      console.log(`  • trackCallSites: ${patch.trackCallSites}`);
-      console.log(`  • enableArchitecture: ${patch.enableArchitecture}`);
-      console.log(`  • cavemanMode: ${patch.cavemanMode ?? 'off'}`);
 
-    // 3. Steering + CLI agent — written here so they include cavemanMode
-    writeSteering(kiroDir, patch.cavemanMode ?? 'off');
-
-    // 4. CLI agent config
-    writeCliAgent(kiroDir);
+      installer.installLate(cwd, cavemanMode);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       console.error(`\n  ✗ Failed to write configuration: ${reason}`);
@@ -132,13 +142,12 @@ export async function runInstaller(): Promise<void> {
     }
 
     // 5. Pre-download Qdrant UI before indexing so Qdrant starts with static content dir
-    if (patch.qdrantDashboard) {
+    if (qdrantDashboard) {
       await ensureQdrantUI(cwd);
     }
 
     // 6. Optionally init + index
-    const doIndex = await ask(rl, '\n  Initialize and index this project now? (Y/n) ');
-    if (doIndex.toLowerCase() !== 'n') {
+    if (shouldOfferIndex && (await ask(rl, '\n  Initialize and index this project now? (Y/n) ')).toLowerCase() !== 'n') {
       const KiroGraph = (await import('../../index')).default;
 
       const fileBytes = new Map<string, { loaded: number; total: number }>();
@@ -190,7 +199,7 @@ export async function runInstaller(): Promise<void> {
       console.log(`  ✓ Indexed ${result.filesIndexed} files, ${result.nodesCreated} symbols, ${result.edgesCreated} edges`);
       cg.close();
 
-      if (patch.typesenseDashboard) {
+      if (typesenseDashboard) {
         const dashboardServer = await openTypesenseDashboard(cwd);
         console.log(`  ${dim}Press Ctrl+C to stop the dashboard server when done.${reset}`);
         await new Promise<void>(resolve => {
@@ -205,13 +214,12 @@ export async function runInstaller(): Promise<void> {
         return; // rl.close() handled in finally
       }
 
-      if (patch.qdrantDashboard) {
+      if (qdrantDashboard) {
         await openQdrantDashboard(cwd);
       }
     }
 
-    console.log('\n  Done! Restart Kiro IDE for the MCP server to load.');
-    console.log('  For Kiro CLI, use the "kirograph" agent: kiro-cli --agent kirograph\n');
+    installer.printNextSteps(cwd);
   } finally {
     rl.close();
   }

--- a/src/bin/installer/instructions.ts
+++ b/src/bin/installer/instructions.ts
@@ -1,0 +1,35 @@
+import { CAVEMAN_RULES, CavemanMode } from './caveman';
+
+export function buildAgentInstructions(cavemanMode?: CavemanMode | 'off'): string {
+  const content = `# KiroGraph
+
+KiroGraph builds a local semantic knowledge graph of this codebase. When the \`kirograph\` MCP server is available, prefer its tools over broad grep/glob/file-read exploration.
+
+## Tool selection
+
+- Start code tasks with \`kirograph_context\`.
+- Find symbols by name with \`kirograph_search\`.
+- Inspect a symbol with \`kirograph_node\`; set \`includeCode: true\` only when source is needed.
+- Trace call flow with \`kirograph_callers\` and \`kirograph_callees\`.
+- Check blast radius before edits with \`kirograph_impact\`.
+- Use \`kirograph_path\` to explain how two symbols connect.
+- Use \`kirograph_type_hierarchy\` for inheritance/interface questions.
+- Use \`kirograph_files\` to inspect indexed file structure.
+- Use \`kirograph_status\` if results seem stale or incomplete.
+- Use \`kirograph_architecture\`, \`kirograph_coupling\`, and \`kirograph_package\` for package/layer questions when architecture analysis is enabled.
+- Use \`kirograph_hotspots\`, \`kirograph_surprising\`, and \`kirograph_diff\` for refactor planning and review.
+
+## Workflow
+
+1. Call \`kirograph_context\` for orientation.
+2. Drill into specific symbols with \`kirograph_node\`.
+3. Use graph traversal tools before reading unrelated files.
+4. Fall back to normal filesystem tools only when the graph is missing, stale, or lacks the needed detail.
+
+If \`.kirograph/\` does not exist, ask whether to run \`kirograph init --index\`.
+`;
+
+  const caveman = cavemanMode && cavemanMode !== 'off' ? CAVEMAN_RULES[cavemanMode] : null;
+  return caveman ? content.trimEnd() + '\n\n' + caveman + '\n' : content;
+}
+

--- a/src/bin/installer/mcp.ts
+++ b/src/bin/installer/mcp.ts
@@ -2,45 +2,16 @@
  * KiroGraph Installer — MCP server registration
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
-
-function ensureDir(p: string): void {
-  fs.mkdirSync(p, { recursive: true });
-}
-
-function readJson(p: string): any {
-  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return {}; }
-}
-
-function writeJson(p: string, data: unknown): void {
-  fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
-}
+import { KIROGRAPH_COMMAND, KIROGRAPH_MCP_ARGS, KIROGRAPH_TOOLS, writeMcpServersConfig } from './common';
 
 export function writeMcpConfig(kiroDir: string): void {
   const mcpPath = path.join(kiroDir, 'settings', 'mcp.json');
-  ensureDir(path.dirname(mcpPath));
-  const existing = readJson(mcpPath);
-  existing.mcpServers = existing.mcpServers ?? {};
-  existing.mcpServers.kirograph = {
-    command: 'kirograph',
-    args: ['serve', '--mcp'],
+  writeMcpServersConfig(mcpPath, {
+    command: KIROGRAPH_COMMAND,
+    args: KIROGRAPH_MCP_ARGS,
     disabled: false,
-    autoApprove: [
-      'kirograph_search',
-      'kirograph_context',
-      'kirograph_callers',
-      'kirograph_callees',
-      'kirograph_impact',
-      'kirograph_node',
-      'kirograph_status',
-      'kirograph_files',
-      'kirograph_dead_code',
-      'kirograph_circular_deps',
-      'kirograph_path',
-      'kirograph_type_hierarchy',
-    ],
-  };
-  writeJson(mcpPath, existing);
+    autoApprove: KIROGRAPH_TOOLS,
+  });
   console.log(`  ✓ MCP server registered in ${mcpPath}`);
 }

--- a/src/bin/installer/targets/claude.ts
+++ b/src/bin/installer/targets/claude.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { CavemanMode } from '../caveman';
+import {
+  appendImportLine,
+  ensureDir,
+  KIROGRAPH_COMMAND,
+  KIROGRAPH_MCP_ARGS,
+  removeMcpServersConfig,
+  removeImportLine,
+  writeMcpServersConfig,
+} from '../common';
+import { buildAgentInstructions } from '../instructions';
+
+const CLAUDE_IMPORT = '@.kirograph/claude.md';
+
+export function installClaudeEarly(projectRoot: string): void {
+  const mcpPath = path.join(projectRoot, '.mcp.json');
+  writeMcpServersConfig(mcpPath, {
+    command: KIROGRAPH_COMMAND,
+    args: KIROGRAPH_MCP_ARGS,
+  });
+  console.log(`  ✓ Claude MCP server registered in ${mcpPath}`);
+}
+
+export function installClaudeLate(projectRoot: string, cavemanMode?: CavemanMode | 'off'): void {
+  const instructionsPath = path.join(projectRoot, '.kirograph', 'claude.md');
+  ensureDir(path.dirname(instructionsPath));
+  fs.writeFileSync(instructionsPath, buildAgentInstructions(cavemanMode));
+  console.log(`  ✓ Claude instructions written to ${instructionsPath}`);
+
+  const memoryPath = path.join(projectRoot, 'CLAUDE.md');
+  const changed = appendImportLine(memoryPath, CLAUDE_IMPORT, '## KiroGraph');
+  console.log(changed
+    ? `  ✓ Claude project memory updated in ${memoryPath}`
+    : `  ✓ Claude project memory already imports ${CLAUDE_IMPORT}`);
+}
+
+export function uninitClaude(projectRoot: string): void {
+  const mcpPath = path.join(projectRoot, '.mcp.json');
+  if (removeMcpServersConfig(mcpPath)) {
+    console.log(`  ✓ Removed kirograph from .mcp.json`);
+  }
+
+  const memoryPath = path.join(projectRoot, 'CLAUDE.md');
+  if (removeImportLine(memoryPath, CLAUDE_IMPORT)) {
+    console.log(`  ✓ Removed KiroGraph import from CLAUDE.md`);
+  }
+}
+
+export function printClaudeNextSteps(): void {
+  console.log('\n  Done! Restart Claude Code for the MCP server and project memory to load.\n');
+}

--- a/src/bin/installer/targets/codex.ts
+++ b/src/bin/installer/targets/codex.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { CavemanMode } from '../caveman';
+import { ensureDir, removeGeneratedBlock, upsertGeneratedBlock } from '../common';
+import { buildAgentInstructions } from '../instructions';
+
+const CODEX_BLOCK_ID = 'codex';
+
+export function installCodexEarly(_projectRoot: string): void {
+  // Codex MCP config is user-scoped. We print the exact config in next steps
+  // instead of writing outside the project from an installer command.
+}
+
+export function installCodexLate(projectRoot: string, cavemanMode?: CavemanMode | 'off'): void {
+  const instructionsPath = path.join(projectRoot, '.kirograph', 'codex.md');
+  ensureDir(path.dirname(instructionsPath));
+  fs.writeFileSync(instructionsPath, buildAgentInstructions(cavemanMode));
+  console.log(`  ✓ Codex instructions written to ${instructionsPath}`);
+
+  const agentsPath = path.join(projectRoot, 'AGENTS.md');
+  const changed = upsertGeneratedBlock(agentsPath, CODEX_BLOCK_ID, '## KiroGraph', buildAgentInstructions(cavemanMode));
+  console.log(changed
+    ? `  ✓ Codex project instructions updated in ${agentsPath}`
+    : `  ✓ Codex project instructions already up to date`);
+}
+
+export function uninitCodex(projectRoot: string): void {
+  const agentsPath = path.join(projectRoot, 'AGENTS.md');
+  if (removeGeneratedBlock(agentsPath, CODEX_BLOCK_ID)) {
+    console.log(`  ✓ Removed KiroGraph block from AGENTS.md`);
+  }
+}
+
+export function printCodexNextSteps(projectRoot: string): void {
+  const escapedPath = projectRoot.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  console.log('\n  Done! Codex project instructions are installed.');
+  console.log('  Add the MCP server to Codex with:');
+  console.log(`    codex mcp add kirograph -- kirograph serve --mcp --path "${escapedPath}"`);
+  console.log('\n  Or add this to ~/.codex/config.toml:');
+  console.log('    [mcp_servers.kirograph]');
+  console.log('    command = "kirograph"');
+  console.log(`    args = ["serve", "--mcp", "--path", "${escapedPath}"]\n`);
+}

--- a/src/bin/installer/targets/index.ts
+++ b/src/bin/installer/targets/index.ts
@@ -1,0 +1,43 @@
+import type { CavemanMode } from '../caveman';
+import type { InstallTarget } from '../common';
+import { installKiroEarly, installKiroLate, printKiroNextSteps } from './kiro';
+import { installClaudeEarly, installClaudeLate, printClaudeNextSteps, uninitClaude } from './claude';
+import { installCodexEarly, installCodexLate, printCodexNextSteps, uninitCodex } from './codex';
+
+export interface TargetInstaller {
+  label: string;
+  installEarly(projectRoot: string): void;
+  installLate(projectRoot: string, cavemanMode?: CavemanMode | 'off'): void;
+  printNextSteps(projectRoot: string): void;
+  uninit?(projectRoot: string): void;
+}
+
+export function getTargetInstaller(target: InstallTarget): TargetInstaller {
+  if (target === 'claude') {
+    return {
+      label: 'Claude Code',
+      installEarly: installClaudeEarly,
+      installLate: installClaudeLate,
+      printNextSteps: printClaudeNextSteps,
+      uninit: uninitClaude,
+    };
+  }
+
+  if (target === 'codex') {
+    return {
+      label: 'Codex',
+      installEarly: installCodexEarly,
+      installLate: installCodexLate,
+      printNextSteps: printCodexNextSteps,
+      uninit: uninitCodex,
+    };
+  }
+
+  return {
+    label: 'Kiro',
+    installEarly: installKiroEarly,
+    installLate: installKiroLate,
+    printNextSteps: printKiroNextSteps,
+  };
+}
+

--- a/src/bin/installer/targets/kiro.ts
+++ b/src/bin/installer/targets/kiro.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+import { CavemanMode } from '../caveman';
+import { writeCliAgent } from '../cli-agent';
+import { writeHooks } from '../hooks';
+import { writeMcpConfig } from '../mcp';
+import { writeSteering } from '../steering';
+
+export function installKiroEarly(projectRoot: string): void {
+  const kiroDir = path.join(projectRoot, '.kiro');
+  writeMcpConfig(kiroDir);
+  writeHooks(kiroDir);
+}
+
+export function installKiroLate(projectRoot: string, cavemanMode?: CavemanMode | 'off'): void {
+  const kiroDir = path.join(projectRoot, '.kiro');
+  writeSteering(kiroDir, cavemanMode);
+  writeCliAgent(kiroDir);
+}
+
+export function printKiroNextSteps(): void {
+  console.log('\n  Done! Restart Kiro IDE for the MCP server to load.');
+  console.log('  For Kiro CLI, use the "kirograph" agent: kiro-cli --agent kirograph\n');
+}
+

--- a/src/mcp/tool-names.ts
+++ b/src/mcp/tool-names.ts
@@ -1,0 +1,21 @@
+export const KIROGRAPH_TOOL_NAMES = [
+  'kirograph_search',
+  'kirograph_context',
+  'kirograph_callers',
+  'kirograph_callees',
+  'kirograph_impact',
+  'kirograph_node',
+  'kirograph_status',
+  'kirograph_files',
+  'kirograph_dead_code',
+  'kirograph_circular_deps',
+  'kirograph_path',
+  'kirograph_architecture',
+  'kirograph_coupling',
+  'kirograph_package',
+  'kirograph_hotspots',
+  'kirograph_surprising',
+  'kirograph_diff',
+  'kirograph_type_hierarchy',
+];
+

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -8,6 +8,7 @@ import * as crypto from 'crypto';
 import KiroGraph, { findNearestKiroGraphRoot } from '../index';
 import type { NodeKind } from '../types';
 import { logError } from '../errors';
+export { KIROGRAPH_TOOL_NAMES } from './tool-names';
 
 const MAX_OUTPUT = 15_000;
 


### PR DESCRIPTION
Tested installation on claude and codex. If .kirograph already exists in local project, just the relevant config files are added.
Codex requires explicit commands to configure the mcp server (but if you don't do that, it still uses to command line to get data):
```
black:pabawi al$ kirograph install --target codex

██╗  ██╗██╗██████╗  ██████╗  ██████╗ ██████╗  █████╗ ██████╗ ██╗  ██╗
██║ ██╔╝██║██╔══██╗██╔═══██╗██╔════╝ ██╔══██╗██╔══██╗██╔══██╗██║  ██║
█████╔╝ ██║██████╔╝██║   ██║██║  ███╗██████╔╝███████║██████╔╝███████║
██╔═██╗ ██║██╔══██╗██║   ██║██║   ██║██╔══██╗██╔══██║██╔═══╝ ██╔══██║
██║  ██╗██║██║  ██║╚██████╔╝╚██████╔╝██║  ██║██║  ██║██║     ██║  ██║
╚═╝  ╚═╝╚═╝╚═╝  ╚═╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝  ╚═╝
                                                                     
  Semantic code knowledge graph for Kiro — 100% local
  Inspired by CodeGraph — original idea by github.com/colbymchenry

─────────────────────── Did you know? ───────────────────────
┌────────────────────────────────────────────────────────────────────┐
│  kirograph impact <symbol> shows the blast radius                    │
│    before you change anything.                                       │
└────────────────────────────────────────────────────────────────────┘

  Workspace: /Users/al/Documents/GITHUB/pabawi

  Install KiroGraph for Codex? (Y/n) 

  ✓ Reusing existing KiroGraph data in /Users/al/Documents/GITHUB/pabawi/.kirograph/
  • semanticEngine: cosine
  • enableEmbeddings: true
  • enableArchitecture: true
  • cavemanMode: off
  ✓ Codex instructions written to /Users/al/Documents/GITHUB/pabawi/.kirograph/codex.md
  ✓ Codex project instructions updated in /Users/al/Documents/GITHUB/pabawi/AGENTS.md

  Done! Codex project instructions are installed.
  Add the MCP server to Codex with:
    codex mcp add kirograph -- kirograph serve --mcp --path "/Users/al/Documents/GITHUB/pabawi"

  Or add this to ~/.codex/config.toml:
    [mcp_servers.kirograph]
    command = "kirograph"
    args = ["serve", "--mcp", "--path", "/Users/al/Documents/GITHUB/pabawi"]
```

Uninstallation asks first if to remove tools specific configs, and then, eventually (default N) to remove the .kirograph dir.
--force option behaviour is preserved.