### PR TITLE
clean up merge conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,7 +440,6 @@
 - `GraphDatabase` exposes `applyDocsSchema()` for docs module access.
 - Installer `installLate` signature extended with `enableDocs` parameter.
 - Build script copies `docs-schema.sql` to dist.
->>>>>>> main
 
 ---
 
@@ -486,7 +485,6 @@
 - **Hooks consolidated**: Replaced four per-file hooks (`kirograph-mark-dirty-on-save`, `kirograph-mark-dirty-on-create`, `kirograph-sync-on-delete`, `kirograph-sync-if-dirty`) with a single `agentStop` hook (`kirograph-sync-if-dirty.kiro.hook`) that uses `askAgent` to tell the agent to sync if any files changed during the session.
 - **Hook file extension**: Migrated from `.json` to `.kiro.hook` extension. The installer automatically migrates existing `.json` hooks and removes legacy files.
 - **Compression hint hook**: `kirograph-compress-hint.kiro.hook` now uses `.kiro.hook` extension (was `.json`).
->>>>>>> main
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,9 @@
     "test": "vitest --run",
     "test:watchmen": "bash scripts/watchmen/test.sh",
     "test:watchmen:skip-llm": "bash scripts/watchmen/test.sh --skip-llm",
-<<<<<<< HEAD
     "test:patterns": "bash scripts/patterns/test.sh",
     "test:sec": "bash scripts/sec/test.sh",
-=======
     "test:turboquant": "bash scripts/turboquant/test.sh",
->>>>>>> feature/turboquant
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "release": "./scripts/release.sh",
     "docs": "npx serve docs"


### PR DESCRIPTION
## Summary

Removes leftover merge conflict markers from CHANGELOG.md and package.json.

## Changes

- CHANGELOG.md: Removed two orphaned >>>>>>> main markers left from a previous merge.
- package.json: Removed conflict markers from a feature/turboquant merge, keeping both test:patterns/test:sec and test:turboquant scripts.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other: ___

## Testing

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] Tested manually (describe below)

### Manual testing done

- Verified no remaining conflict markers across the entire codebase.
- No functional code changes — documentation and config cleanup only.

## Checklist

- [x] Code follows the project style
- [ ] Self-reviewed the diff
- [ ] Updated documentation (if user-facing change)
- [ ] Updated CHANGELOG.md (if user-facing change)
- [x] No breaking changes (or clearly documented)
