### PR TITLE
fix: security manifest scanner respects config include/exclude patterns

### DIFF
--- a/src/architecture/index.ts
+++ b/src/architecture/index.ts
@@ -32,7 +32,10 @@ export class ArchitectureAnalyzer {
 
     // ── 1. Parse manifests ─────────────────────────────────────────────────────
     log('architecture: parsing manifests');
-    const manifestPackages = await parseAllManifests(this.projectRoot);
+    const manifestPackages = await parseAllManifests(this.projectRoot, {
+      include: this.config.include,
+      exclude: this.config.exclude,
+    });
 
     // ── 2. Get all indexed files ───────────────────────────────────────────────
     const allFiles = this.db.getAllFiles().map(f => f.path); // relative paths

--- a/src/architecture/manifest/index.ts
+++ b/src/architecture/manifest/index.ts
@@ -59,14 +59,36 @@ export function registerManifestParser(parser: ManifestParser): void {
   else MANIFEST_PARSERS.push(parser);
 }
 
+export interface ManifestScanOptions {
+  include?: string[];
+  exclude?: string[];
+}
+
 /**
  * Walk projectRoot looking for manifest files, parse each, deduplicate, and
  * return all detected packages. Packages from manifests take priority; the
  * deduplication ensures that a workspace root pom.xml and a sub-module
  * pom.xml don't produce overlapping directory mappings.
+ *
+ * When scanOptions.include is provided, only manifests within included paths
+ * are processed (aligning with the code graph scope).
  */
-export async function parseAllManifests(projectRoot: string): Promise<ArchPackage[]> {
-  const manifestPaths = _findManifests(projectRoot);
+export async function parseAllManifests(projectRoot: string, scanOptions?: ManifestScanOptions): Promise<ArchPackage[]> {
+  let manifestPaths = _findManifests(projectRoot);
+
+  // Filter by include/exclude if provided
+  if (scanOptions?.include && scanOptions.include.length > 0) {
+    const picomatch = require('picomatch');
+    const includeMatchers = scanOptions.include.map((p: string) => picomatch(p));
+    const excludeMatchers = (scanOptions.exclude ?? []).map((p: string) => picomatch(p));
+    manifestPaths = manifestPaths.filter(absPath => {
+      const rel = path.relative(projectRoot, absPath).replace(/\\/g, '/');
+      const included = includeMatchers.some((m: (s: string) => boolean) => m(rel));
+      if (!included) return false;
+      return !excludeMatchers.some((m: (s: string) => boolean) => m(rel));
+    });
+  }
+
   const all: ArchPackage[] = [];
   const seenIds = new Set<string>();
 

--- a/src/security/manifest/adapter.ts
+++ b/src/security/manifest/adapter.ts
@@ -16,6 +16,15 @@ import { getAllManifestParsers } from '../../architecture/manifest/index';
 import type { ManifestParser as ArchManifestParser, ArchPackage } from '../../architecture/types';
 import type { ParsedDependency, ManifestParseResult } from '../types';
 
+// ── Include/Exclude filter support ────────────────────────────────────────────
+
+export interface ManifestScanOptions {
+  /** Glob patterns for paths to include (relative to projectRoot). Empty = all. */
+  include?: string[];
+  /** Glob patterns for paths to exclude (relative to projectRoot). */
+  exclude?: string[];
+}
+
 // ── Plugin Interface ──────────────────────────────────────────────────────────
 
 /**
@@ -56,9 +65,11 @@ export class SecurityManifestAdapter {
   /** Standalone plugins have no corresponding architecture parser — they own their own discovery. */
   private readonly standalonePlugins: Map<string, VersionExtractionPlugin> = new Map();
   private readonly projectRoot: string;
+  private readonly scanOptions: ManifestScanOptions;
 
-  constructor(projectRoot: string) {
+  constructor(projectRoot: string, scanOptions?: ManifestScanOptions) {
     this.projectRoot = projectRoot;
+    this.scanOptions = scanOptions ?? {};
     this.archParsers = getAllManifestParsers();
   }
 
@@ -98,10 +109,29 @@ export class SecurityManifestAdapter {
   /**
    * Discover all manifest files in the project tree.
    * Includes files known to architecture parsers AND files from standalone plugins.
+   * Respects config include/exclude patterns when provided.
    * Returns absolute paths.
    */
   discoverManifests(): string[] {
-    return this._findManifests(this.projectRoot);
+    const allManifests = this._findManifests(this.projectRoot);
+
+    // If no include patterns, return all discovered manifests
+    if (!this.scanOptions.include || this.scanOptions.include.length === 0) {
+      return allManifests;
+    }
+
+    // Filter manifests to only those within included paths
+    const picomatch = require('picomatch');
+    const includeMatchers = this.scanOptions.include.map((p: string) => picomatch(p));
+    const excludeMatchers = (this.scanOptions.exclude ?? []).map((p: string) => picomatch(p));
+
+    return allManifests.filter(absPath => {
+      const rel = path.relative(this.projectRoot, absPath).replace(/\\/g, '/');
+      const included = includeMatchers.some((m: (s: string) => boolean) => m(rel));
+      if (!included) return false;
+      const excluded = excludeMatchers.some((m: (s: string) => boolean) => m(rel));
+      return !excluded;
+    });
   }
 
   /**

--- a/src/security/manifest/parser.ts
+++ b/src/security/manifest/parser.ts
@@ -9,7 +9,7 @@
  *
  * Node ID format: `dep:<ecosystem>:<name>` (e.g. `dep:npm:express`)
  */
-import { SecurityManifestAdapter, type VersionExtractionPlugin } from './adapter';
+import { SecurityManifestAdapter, type VersionExtractionPlugin, type ManifestScanOptions } from './adapter';
 import { parseNpmManifest } from './plugins/npm';
 import { parseMavenManifest } from './plugins/maven';
 import { parseGoManifest } from './plugins/go';
@@ -341,10 +341,10 @@ export class ManifestParser {
   private readonly db: GraphDatabase;
   private readonly projectRoot: string;
 
-  constructor(db: GraphDatabase, projectRoot: string) {
+  constructor(db: GraphDatabase, projectRoot: string, scanOptions?: ManifestScanOptions) {
     this.db = db;
     this.projectRoot = projectRoot;
-    this.adapter = new SecurityManifestAdapter(projectRoot);
+    this.adapter = new SecurityManifestAdapter(projectRoot, scanOptions);
 
     // Wrapped plugins (arch parser exists — ecosystem must match archParser.name)
     this.adapter.registerPlugin(createNpmPlugin());

--- a/src/security/pipeline.ts
+++ b/src/security/pipeline.ts
@@ -60,7 +60,10 @@ export class SecurityPipeline {
     // ── Phase 1: Manifest Parsing ─────────────────────────────────────────────
     onProgress?.('manifest-parsing', 0, 4);
 
-    const parser = new ManifestParser(this.db, this.projectRoot);
+    const parser = new ManifestParser(this.db, this.projectRoot, {
+      include: this.config.include,
+      exclude: this.config.exclude,
+    });
     const parseResult = await parser.parseAll();
 
     result.manifestsDiscovered = parseResult.manifestsParsed;


### PR DESCRIPTION
The security module's manifest discovery (go.mod, package.json, etc.) walked the entire projectRoot directory tree, ignoring the config's include/exclude arrays. This caused warnings for modules not in the include list (e.g., scanning ota-module/go.mod when ota-module was never included for indexing).

Fix: Pass config.include and config.exclude to SecurityManifestAdapter. Filter discovered manifest paths against the include patterns using picomatch (already a dependency). Only manifests within included paths are processed.

This aligns security scanning scope with the code graph scope — if a module isn't in the include array, its manifests won't be scanned for vulnerabilities.

## Summary

Brief description of what this PR does.

## Changes

- 
- 
- 

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other: ___

## Testing

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] Tested manually (describe below)

- Tested on a 15K-file workspace. My module manifests are correctly filtered (0 found when excluded). Other manifests found (19). No breaking changes — if the include array is empty, all manifests are scanned (backward-compatible).

### Manual testing done



## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [ ] Updated documentation (if user-facing change)
- [ ] Updated CHANGELOG.md (if user-facing change)
- [x] No breaking changes (or clearly documented)
