### PR TITLE
fix: framework detection works in multi-root workspaces

### DIFF
--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -143,6 +143,7 @@ export function registerFrameworkResolver(resolver: FrameworkResolver): void {
 function buildResolutionContext(projectRoot: string, db: GraphDatabase): ResolutionContext {
   const fileCache = new Map<string, string | null>();
   const nodeCache = new Map<string, Node[]>();
+  const allIndexedFiles = db.getAllFiles().map(f => f.path);
 
   return {
     getNodesInFile(filePath: string): Node[] {
@@ -158,24 +159,41 @@ function buildResolutionContext(projectRoot: string, db: GraphDatabase): Resolut
       return db.getNodesByKind(kind);
     },
     fileExists(filePath: string): boolean {
-      return fs.existsSync(path.join(projectRoot, filePath));
+      // Check root first
+      if (fs.existsSync(path.join(projectRoot, filePath))) return true;
+      // Multi-root workspace: check if any indexed file matches the filename
+      const basename = path.basename(filePath);
+      return allIndexedFiles.some(f => f.endsWith('/' + basename) || f === basename);
     },
     readFile(filePath: string): string | null {
       if (fileCache.has(filePath)) return fileCache.get(filePath)!;
-      try {
-        const content = fs.readFileSync(path.join(projectRoot, filePath), 'utf8');
-        fileCache.set(filePath, content);
-        return content;
-      } catch {
-        fileCache.set(filePath, null);
-        return null;
+      // Try root first
+      const rootPath = path.join(projectRoot, filePath);
+      if (fs.existsSync(rootPath)) {
+        try {
+          const content = fs.readFileSync(rootPath, 'utf8');
+          fileCache.set(filePath, content);
+          return content;
+        } catch { /* fall through */ }
       }
+      // Multi-root workspace: find first matching file in indexed paths
+      const basename = path.basename(filePath);
+      const match = allIndexedFiles.find(f => f.endsWith('/' + basename) || f === basename);
+      if (match) {
+        try {
+          const content = fs.readFileSync(path.join(projectRoot, match), 'utf8');
+          fileCache.set(filePath, content);
+          return content;
+        } catch { /* fall through */ }
+      }
+      fileCache.set(filePath, null);
+      return null;
     },
     getProjectRoot(): string {
       return projectRoot;
     },
     getAllFiles(): string[] {
-      return db.getAllFiles().map(f => f.path);
+      return allIndexedFiles;
     },
   };
 }


### PR DESCRIPTION
The framework detection context (fileExists, readFile) only checked the workspace root directory. In multi-root workspaces where module configs (angular.json, requirements.txt, go.mod) are nested in subdirectories, frameworks like Angular, FastAPI, and Docker Compose were never detected.

Fix: When the root-level file doesn't exist, search through indexed file paths (from the DB) for matching filenames. This enables detection in nested submodules without changing any individual resolver's detect() logic.

Affected frameworks (now detected in multi-root workspaces):
- Angular (angular.json in taf-module/, core-module/)
- FastAPI (requirements.txt with 'fastapi' in dlm-module/)
- Docker Compose (docker-compose.yaml in wspc-module/)

Note: Gin and Cobra still won't be detected because:
- Gin: generic 'go' resolver detects Go but doesn't distinguish Gin
- Cobra: no resolver exists for Cobra (CLI framework, no routes)

## Summary

Brief description of what this PR does.

## Changes

- 
- 
- 

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other: ___

## Testing

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] Tested manually (describe below)

### Manual testing done



## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [ ] Updated documentation (if user-facing change)
- [ ] Updated CHANGELOG.md (if user-facing change)
- [x] No breaking changes (or clearly documented)
